### PR TITLE
Fix addon ZIP installation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,8 +24,8 @@ bl_info = {
 
 import bpy
 
-from texturecompactor import ui
-from texturecompactor import core
+from . import ui
+from . import core
 
 
 classes = (

--- a/core.py
+++ b/core.py
@@ -3,9 +3,9 @@ import time
 import bpy
 import os
 
-from texturecompactor import web
-from texturecompactor import settings
-from texturecompactor import pro
+from . import web
+from . import settings
+from . import pro
 
 # TODO: 16/32 bit float images
 # TODO: image sequence support

--- a/pro.py
+++ b/pro.py
@@ -1,4 +1,4 @@
-from texturecompactor import settings
+from . import settings
 import bpy
 import hashlib
 import os

--- a/ui.py
+++ b/ui.py
@@ -3,8 +3,8 @@ import concurrent.futures
 
 import bpy
 
-from texturecompactor import core
-from texturecompactor import settings
+from . import core
+from . import settings
 
 
 class TEXCOMPACTOR_PT_main_panel(bpy.types.Panel):


### PR DESCRIPTION
This update tweaks the import paths so the addon works smoothly when installed from the git zip download from the web interface. Before, there were some import errors because the paths didn’t quite line up with how Blender handles modules in a zip installation.